### PR TITLE
Stemplot refactored

### DIFF
--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -72,5 +72,8 @@ function stemplot(v::AbstractVector;
   end
 
   println("\nKey: 1$(divider)0 = $(scale)")
-
+  # Description of where the decimal is
+  ndigits = abs(trunc(Int,log10(scale)))
+  right_or_left = ifelse(trunc(Int,log10(scale)) < 0, "left", "right")
+  println("The decimal is $(ndigits) digit(s) to the $(right_or_left) of $(divider)")
 end

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -22,6 +22,7 @@ TODO
 Author(s)
 ========
 - Alex Hallam (Github: https://github.com/alexhallam)
+- Matthew Amos (Github: https://github.com/equinetic)
 Examples
 ========
 `stemplot(rand(1:100,80))`
@@ -38,84 +39,38 @@ See Also
 ========
 `histogram`
 """
-function stemplot(
-                  v::Vector;
+function stemplot(v::AbstractVector;
+                  scale=10,
                   divider::AbstractString="|",
-                  scale=10
+                  padchar::AbstractString=" "
                   )
-    v = convert(Array{AbstractFloat,1}, v)
-    left_ints,leaves = divrem(sort(v),scale)
-    leaves_of_zero_left_ints = leaves[left_ints .==0]
-    neg_zero_leaves = leaves_of_zero_left_ints[leaves_of_zero_left_ints.<0]
-    pos_zero_leaves = leaves_of_zero_left_ints[leaves_of_zero_left_ints.>=0]
+  v = convert(Vector{AbstractFloat}, v)
 
-    # Delete pos_zero_leaves that are equal to neg_zero_leaves
-    deleteat!(pos_zero_leaves, findin(pos_zero_leaves, neg_zero_leaves))
+  # Initial Stems, Leaves
+  left_ints, leaves = divrem(v, scale)
 
-    # Truncate values, so trailing decimals do not show
-    leaves = trunc(Int,leaves*10)
-    neg_zero_leaves = trunc(Int,neg_zero_leaves*10)
-    pos_zero_leaves = trunc(Int,pos_zero_leaves*10)
+  # Negative zeros => -0.00
+  left_ints[indices(v, 1)[(left_ints .== 0) & (sign(leaves) .== -1)]] = -0.00
 
-    # Create range of values for stems. This is so the empty sets are not missed
-    stems = collect(minimum(left_ints) : maximum(left_ints))
+  # Stem range => sorted hexidecimal
+  stems= minimum(left_ints):maximum(left_ints)
+  stems = sort(unique(vcat(stems, left_ints)))
+  stems = num2hex.(stems); left_ints = num2hex.(left_ints)
 
-    # Get the leaves associated with a given stem
-    getleaves(stem) = leaves[left_ints .== stem]
+  getlabel(s) = s == num2hex(-0.) ? "-0" : string(Int(hex2num(s)))
+  getleaf(stem) = sort(abs(trunc(Int, leaves[left_ints .== stem])))
 
-    # Dict mapping stems to leaves
-    dict = Dict(stem => getleaves(stem) for stem in stems)
+  labels = getlabel.(stems)
+  lbl_len = maximum(length.(labels))
+  col_len = lbl_len + 1
 
-    # Replace values at positive 0 with leaves associated with positive 0 only
-    dict[0] = pos_zero_leaves
+  # Stem | Leaf print routine
+  for i = 1:length(stems)
+    stem = rpad(lpad(labels[i], lbl_len, padchar), col_len, padchar)
+    leaf = join(string.(getleaf(stems[i])))
+    println(stem, divider, padchar, leaf)
+  end
 
-    # Handle -0 stems and associated leaves
-    if any(leaves_of_zero_left_ints .< 0.0)
-        dict[-0.0] = neg_zero_leaves
-        # Delete negative values in dictionary with 0.0 as stem
-        # add -0.0 dict with values
-        push!(stems, -0.0)
-        sort!(stems)
-    end
+  println("\nKey: 1$(divider)0 = $(scale)")
 
-    # Prep and print stemplot
-    # Set pad
-    pad = "  "
-    one_space = " "
-    # width needed for proper formating of stem-to-divider
-    max_stem_width = length(string(maximum(round(Int64,stems))))
-    println()
-    for stem in stems
-        stemleaves = dict[stem]
-        # print the stem and divider
-        each_stem_width = length(string(round(Int64,stem)))
-        print(pad, one_space^(max_stem_width+2-each_stem_width), rpad(round(Int64,stem), 1),one_space, divider, " ")
-        # if leaves exist print them without dict brackets
-        if !isempty(stemleaves)
-            leaf_string = string(stemleaves)[2:(end-1)]
-            print(replace(leaf_string,r"[,-]",""))
-        end
-        println()
-    end
-
-    # Get and print key
-    # Get index of last stem
-    key_stem_index = findlast(s -> !isempty(getleaves(stem)),stems)
-    # If a key_stem exsits
-    if key_stem_index > 0
-        key_stem = trunc(Int,stems[key_stem_index])
-        # Print first leaf in stem and remove negative on leaf, if leaf is negative.
-        key_leaf = norm(dict[key_stem][1])
-        if scale == 1
-            key_value = round(key_stem*scale+key_leaf*.1,1)
-        else
-            key_value = round(key_stem*scale+key_leaf,1)
-        end
-        # println("\n",pad, "Key: $(key_stem)$(divider)$(key_leaf) = $(key_value)")
-
-        # Description of where the decimal is
-        ndigits = abs(trunc(Int,log10(scale)))
-        right_or_left = ifelse(trunc(Int,log10(scale)) < 0, "left", "right")
-        println("\n",pad,"Description: The decimal is $(ndigits) digit(s) to the $(right_or_left) of $(divider)")
-    end
 end

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -52,7 +52,7 @@ function stemplot(v::AbstractVector;
   # Negative zeros => -0.00
   left_ints[indices(v, 1)[(left_ints .== 0) & (sign(leaves) .== -1)]] = -0.00
 
-  # Stem range => sorted hexidecimal
+  # Stem range => sorted hexadecimal
   stems= minimum(left_ints):maximum(left_ints)
   stems = sort(unique(vcat(stems, left_ints)))
   stems = num2hex.(stems); left_ints = num2hex.(left_ints)


### PR DESCRIPTION
I was able to handle negative zeros by converting the stems into hexadecimals, which I think makes things a little easier to manage:

```julia
println( num2hex(0.0)  )
println( num2hex(-0.0) )

julia> "0000000000000000"
julia> "8000000000000000"
```

I loop through a pre-sorted list of these hexadecimal values which requires only minor intervention for -0.

If there are any bugs that you'd like a second set of eyes on I'm happy to help, I'd like to see this thing get merged into UnicodePlots.