### PR TITLE
Back-to-back plots, trim parameter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,8 @@
 # TODO
 
-- [ ] Create type for stemplot so that it can be updated/refreshed with `stemplot!()`
-- [ ] Add `trim::Bool` parameter to limit output
+- ~~[ ] Create type for stemplot so that it can be updated/refreshed with `stemplot!()`~~
+  - Current structure doesn't have mutating parameters
+- [x] Add `trim::Bool` parameter to limit output
 - [ ] Add `precision::Bool` parameter to round output. Example:
 
 ```julia
@@ -32,7 +33,7 @@ julia> stemplot!(mystemplot, split=true)
  3 | 88
 ```
 
-- [ ] Create method for back-to-back stem plots which can be useful for comparing
+- [x] Create method for back-to-back stem plots which can be useful for comparing
 distributions:
 
 ```julia
@@ -42,3 +43,6 @@ julia> stemplot(dataset1, dataset2)
        | 2 | 89
   6600 | 3 | 00136
 ```
+
+- [ ] 0.6 proof everything
+- [ ] Update docs

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,20 @@
 # TODO
 
 - [ ] Create type for stemplot so that it can be updated/refreshed with `stemplot!()`
-- [ ] Add `trim::Bool` parameter - round down by base *`scale`* to reduce digits
+- [ ] Add `trim::Bool` parameter to limit output
+- [ ] Add `precision::Bool` parameter to round output. Example:
+
+```julia
+julia> v = [8,9,43,44]
+julia> stemplot(v, scale=100)
+0 | 894344
+
+# The 43 and 44 are misleading in this case, so
+# a precision parameter may be of use
+julia > stemplot(v, scale=100, precision=10)
+0 | 0044
+```
+
 - [ ] Add `split::Bool` parameter - break a stem across two or more lines if there's
 too many digits (or should this be `split::Int`, `maxdigits::Int`...?). For example:
 

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -80,7 +80,8 @@ stemplot(randn(50),scale = 1)
 ```
 
 """
-function stemplot(plt::Stemplot, scale=10;
+function stemplot(plt::Stemplot;
+                  scale=10,
                   divider::AbstractString="|",
                   padchar::AbstractString=" ",
                   trim::Bool=false,
@@ -112,7 +113,8 @@ function stemplot(plt::Stemplot, scale=10;
 end
 
 # back to back
-function stemplot(plt1::Stemplot, plt2::Stemplot, scale=10;
+function stemplot(plt1::Stemplot, plt2::Stemplot;
+                  scale=10,
                   divider::AbstractString="|",
                   padchar::AbstractString=" ",
                   trim::Bool=false,
@@ -139,8 +141,6 @@ function stemplot(plt1::Stemplot, plt2::Stemplot, scale=10;
       left_leaf = lpad(reverse(left_leaves[i]), leftleaf_len, padchar)
       right_leaf = stemplot_getleaf(stems[i], li_2, leaves2)
       stem = rpad(lpad(labels[i], col_len, padchar), col_len+1, padchar)
-      #stem = rpad(lpad(labels[i], lbl_len, padchar), col_len, padchar)
-      #leaf = join(string.(stemplot_getleaf(stems[i], left_ints, leaves)))
       println(left_leaf, padchar, divider, stem, divider, padchar, right_leaf)
     end
 
@@ -154,20 +154,20 @@ function stemplot(plt1::Stemplot, plt2::Stemplot, scale=10;
 end
 
 # Single
-function stemplot(v::AbstractVector, scale=10; args...)
+function stemplot(v::AbstractVector; scale=10, args...)
   # Stemplot object
   plt = Stemplot(v, scale=scale)
 
   # Dispatch to plot routine
-  stemplot(plt; args...)
+  stemplot(plt; scale=scale, args...)
 end
 
 # Back to back
-function stemplot(v1::AbstractVector, v2::AbstractVector, scale=10; args...)
+function stemplot(v1::AbstractVector, v2::AbstractVector; scale=10, args...)
   # Stemplot object
   plt1 = Stemplot(v1, scale=scale)
   plt2 = Stemplot(v2, scale=scale)
 
   # Dispatch to plot routine
-  stemplot(plt1, plt2; args...)
+  stemplot(plt1, plt2; scale=scale, args...)
 end

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -120,14 +120,12 @@ function stemplot(plt1::Stemplot, plt2::Stemplot;
                   trim::Bool=false,
                   )
 
-    li_1 = plt1.left_ints
-    li_2 = plt2.left_ints
     leaves1 = plt1.leaves
     leaves2 = plt2.leaves
 
-    stems1, li_1 = getstems(li_1, trim=trim)
-    stems2, li_2 = getstems(li_2, trim=trim)
-    stems = unique(vcat(stems1, stems2))
+    stems1, li_1 = getstems(plt1.left_ints, trim=trim)
+    stems2, li_2 = getstems(plt2.left_ints, trim=trim)
+    stems, = getstems(vcat(plt1.left_ints, plt2.left_ints), trim=trim)
 
     labels = stemplot_getlabel.(stems)
     lbl_len = maximum(length.(labels))

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -20,7 +20,7 @@ function getstems(left_ints::Vector{AbstractFloat}; trim::Bool=false)
 end
 
 stemplot_getlabel(s) = s == num2hex(-0.) ? "-0" : string(Int(hex2num(s)))
-stemplot_getleaf(s, l_i, lv) = sort(abs.(trunc(Int, lv[l_i .== s])))
+stemplot_getleaf(s, l_i, lv) = join(string.( sort(abs.(trunc(Int, lv[l_i .== s]))) ))
 
 """
 `stemplot(v; nargs...)`->` Plot`
@@ -98,7 +98,7 @@ function stemplot(plt::Stemplot, scale=10;
     # Stem | Leaf print routine
     for i = 1:length(stems)
       stem = rpad(lpad(labels[i], lbl_len, padchar), col_len, padchar)
-      leaf = join(string.(stemplot_getleaf(stems[i], left_ints, leaves)))
+      leaf = stemplot_getleaf(stems[i], left_ints, leaves)
       println(stem, divider, padchar, leaf)
     end
 
@@ -123,17 +123,22 @@ function stemplot(plt1::Stemplot, plt2::Stemplot, scale=10;
     leaves1 = plt1.leaves
     leaves2 = plt2.leaves
 
-    stems, left_ints = getstems(vcat(li_1, li_2), trim=trim)
+    stems1, li_1 = getstems(li_1, trim=trim)
+    stems2, li_2 = getstems(li_2, trim=trim)
+    stems = unique(vcat(stems1, stems2))
 
     labels = stemplot_getlabel.(stems)
     lbl_len = maximum(length.(labels))
     col_len = lbl_len + 1
 
     # Stem | Leaf print routine
+    left_leaves = [stemplot_getleaf(stems[i], li_1, leaves1) for i=1:length(stems)]
+    leftleaf_len = maximum(length.(left_leaves))
+
     for i = 1:length(stems)
-      left_leaf = ""
-      right_leaf = ""
-      stem = ""
+      left_leaf = lpad(reverse(left_leaves[i]), leftleaf_len, padchar)
+      right_leaf = stemplot_getleaf(stems[i], li_2, leaves2)
+      stem = rpad(lpad(labels[i], col_len, padchar), col_len+1, padchar)
       #stem = rpad(lpad(labels[i], lbl_len, padchar), col_len, padchar)
       #leaf = join(string.(stemplot_getleaf(stems[i], left_ints, leaves)))
       println(left_leaf, padchar, divider, stem, divider, padchar, right_leaf)
@@ -164,9 +169,5 @@ function stemplot(v1::AbstractVector, v2::AbstractVector, scale=10; args...)
   plt2 = Stemplot(v2, scale=scale)
 
   # Dispatch to plot routine
-  stemplot(plt1, pl2; args...)
-end
-
-# mutating
-function stemplot!()::Stemplot
+  stemplot(plt1, plt2; args...)
 end

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -1,3 +1,6 @@
+type
+
+
 """
 `stemplot(v; nargs...)`->` Plot`
 
@@ -59,7 +62,8 @@ stemplot(randn(50),scale = 1)
 function stemplot(v::AbstractVector;
                   scale=10,
                   divider::AbstractString="|",
-                  padchar::AbstractString=" "
+                  padchar::AbstractString=" ",
+                  trim::Bool=false,
                   )
   v = convert(Vector{AbstractFloat}, v)
 
@@ -70,8 +74,8 @@ function stemplot(v::AbstractVector;
   left_ints[(left_ints .== 0) .& (sign.(leaves) .== -1)] = -0.00
 
   # Stem range => sorted hexadecimal
-  stems= minimum(left_ints):maximum(left_ints)
-  stems = sort(unique(vcat(stems, left_ints)))
+  stemrng= minimum(left_ints):maximum(left_ints)
+  stems = trim ? sort(unique(left_ints)) : sort(unique(vcat(stemrng, left_ints)))
   stems = num2hex.(stems); left_ints = num2hex.(left_ints)
 
   getlabel(s) = s == num2hex(-0.) ? "-0" : string(Int(hex2num(s)))

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -2,7 +2,7 @@ type Stemplot
   left_ints::Vector{AbstractFloat}
   leaves::Vector{AbstractFloat}
 
-  function Stemplot(v::AbstractVector; scale=10)
+  function Stemplot{T<:Real}(v::AbstractVector{T}; scale=10)
     v = convert(Vector{AbstractFloat}, v)
     left_ints, leaves = divrem(v, scale)
     left_ints[(left_ints .== 0) .& (sign.(leaves) .== -1)] = -0.00
@@ -154,7 +154,7 @@ function stemplot(plt1::Stemplot, plt2::Stemplot;
 end
 
 # Single
-function stemplot(v::AbstractVector; scale=10, args...)
+function stemplot{T<:Real}(v::AbstractVector{T}; scale=10, args...)
   # Stemplot object
   plt = Stemplot(v, scale=scale)
 
@@ -163,7 +163,7 @@ function stemplot(v::AbstractVector; scale=10, args...)
 end
 
 # Back to back
-function stemplot(v1::AbstractVector, v2::AbstractVector; scale=10, args...)
+function stemplot{T<:Real}(v1::AbstractVector{T}, v2::AbstractVector; scale=10, args...)
   # Stemplot object
   plt1 = Stemplot(v1, scale=scale)
   plt2 = Stemplot(v2, scale=scale)

--- a/src/stemplot.jl
+++ b/src/stemplot.jl
@@ -2,7 +2,7 @@ type Stemplot
   left_ints::Vector{AbstractFloat}
   leaves::Vector{AbstractFloat}
 
-  function Stemplot(v::AbstractVector)
+  function Stemplot(v::AbstractVector; scale=10)
     v = convert(Vector{AbstractFloat}, v)
     left_ints, leaves = divrem(v, scale)
     left_ints[(left_ints .== 0) .& (sign.(leaves) .== -1)] = -0.00
@@ -80,8 +80,7 @@ stemplot(randn(50),scale = 1)
 ```
 
 """
-function stemplot(plt::Stemplot;
-                  scale=10,
+function stemplot(plt::Stemplot, scale=10;
                   divider::AbstractString="|",
                   padchar::AbstractString=" ",
                   trim::Bool=false,
@@ -113,8 +112,7 @@ function stemplot(plt::Stemplot;
 end
 
 # back to back
-function stemplot(plt1::Stemplot, plt2::Stemplot;
-                  scale=10,
+function stemplot(plt1::Stemplot, plt2::Stemplot, scale=10;
                   divider::AbstractString="|",
                   padchar::AbstractString=" ",
                   trim::Bool=false,
@@ -151,19 +149,19 @@ function stemplot(plt1::Stemplot, plt2::Stemplot;
 end
 
 # Single
-function stemplot(v::AbstractVector; args...)
+function stemplot(v::AbstractVector, scale=10; args...)
   # Stemplot object
-  plt = Stemplot(v)
+  plt = Stemplot(v, scale=scale)
 
   # Dispatch to plot routine
   stemplot(plt; args...)
 end
 
 # Back to back
-function stemplot(v1::AbstractVector, v2::AbstractVector; args...)
+function stemplot(v1::AbstractVector, v2::AbstractVector, scale=10; args...)
   # Stemplot object
-  plt1 = Stemplot(v1)
-  plt2 = Stemplot(v2)
+  plt1 = Stemplot(v1, scale=scale)
+  plt2 = Stemplot(v2, scale=scale)
 
   # Dispatch to plot routine
   stemplot(plt1, pl2; args...)


### PR DESCRIPTION
Started to try to make some headway on the proposed enhancements, let me know what you think.

I'm not sure if this is the best strategy, but what I did was define a new type `Stemplot` and leaned on multiple dispatch. 

Passing your vector of numbers `stemplot(v)` or `stemplot(v1, v2)` falls on methods that will initialize one or two `Stemplot` types, which are then passed to a method accepting ::Stemplot that performs the actual print routine. I haven't thoroughly tested it but it looks like it's doing what it's supposed to:

```julia
julia> v1 = rand(-10:25, 10)
julia> v2 = rand(-15:40, 20)
julia> stemplot(v1, v2)
       | -1 | 125
877541 | -0 | 48
    63 |  0 | 347
     5 |  1 | 139
     3 |  2 | 027789
       |  3 | 89
       |  4 | 0

Key: 1|0 = 10
The decimal is 1 digit(s) to the right of |
```